### PR TITLE
Add optional ReferenceNumber to package options.

### DIFF
--- a/lib/omniship/carriers/ups.rb
+++ b/lib/omniship/carriers/ups.rb
@@ -270,6 +270,17 @@ module Omniship
                     }
                   end
                 }
+                if package.options[:references].present?
+                  package.options[:references].each do |reference|
+                    xml.ReferenceNumber {
+                      xml.Code reference[:code]
+                      xml.Value reference[:value]
+                      if reference[:barcode]
+                        xml.BarCodeIndicator
+                      end
+                    }
+                  end
+                end
               }
             end
             xml.LabelSpecification {


### PR DESCRIPTION
ReferenceNumbers can be included with a shipping package. They contain a
code which needs to have one of the accepted values as per Appendix I of
the Shipping Package XML Developer Guide and a value. In addition the
value of the ReferenceNumber can be generated as a barcode.
