### PR TITLE
Check for config file existance before loading.

### DIFF
--- a/lib/omniship.rb
+++ b/lib/omniship.rb
@@ -32,8 +32,8 @@ def Omniship.setup
     @config = File.join(@root, "config", "omniship.yml").freeze
     @keys   = %w{ username password key account meter }.map { |v| v.freeze }.freeze
     require boot unless defined? Rails.env
-    @config = YAML.load_file(@config) || false
-    if @config != false
+    if File.exists? @config
+      @config = YAML.load_file(@config)
       raise "Invalid omniship configuration file: #{@config}" unless @config.is_a?(Hash)
       if (@config.keys & @keys).sort == @keys.sort and !@config.has_key?(Rails.env)
         @config[Rails.env] = {


### PR DESCRIPTION
Previously if omniship.yml did not exist in config folder of application
an Errno::ENOENT error would be raised. This change checks for file
existance before attempting to load_file. This is needed so settings can be
passed as options to carrier, without the need for a config file.
